### PR TITLE
Fix component being rendered twice

### DIFF
--- a/src/main/Embeddable.js
+++ b/src/main/Embeddable.js
@@ -9,7 +9,7 @@ export default class Embeddable extends React.Component {
     }
 
     async componentDidUpdate(prevProps) {
-        if (didPropsChange(this.props, prevProps)) {
+        if (didPropsChange(this.props, prevProps) && this.chart) {
             this.destroyChart();
             this.createAndRenderChart()
         }


### PR DESCRIPTION
The problem is that it's rendering a second chart because a component re-render is triggered before the current chart has finished being rendered as it's waiting for the script to be loaded from the cdn. So it doesn't destroy the current one as it hasn't finished being rendered yet and therefore `this.chart` is undefined. We can just only cause the chart to be destroyed and rendered if `this.chart` is set. 

Before
![image](https://user-images.githubusercontent.com/29544390/93459625-e44c0380-f8d9-11ea-985d-438a554ed421.png)

After
![image](https://user-images.githubusercontent.com/29544390/93459640-eada7b00-f8d9-11ea-9123-e1fcf7b9ad3e.png)
