### PR TITLE
Removed support for old browsers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,12 @@
 {
-  "presets": ["env"],
+  "presets": [
+    [
+      "env",
+      {
+        "exclude": ["transform-regenerator"]
+      }
+    ]
+  ],
   "plugins": [
     "transform-object-rest-spread",
     "transform-react-jsx"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seatsio/seatsio-react",
-  "version": "10.1.0",
+  "version": "11.0.0",
   "main": "build/index.js",
   "repository": {
     "type": "git",
@@ -37,8 +37,7 @@
   },
   "dependencies": {
     "fast-deep-equal": "2.0.1",
-    "react-fast-compare": "2.0.4",
-    "regenerator-runtime": "^0.13.2"
+    "react-fast-compare": "2.0.4"
   },
   "jest": {
     "verbose": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 var path = require('path');
 module.exports = {
-    entry: ['babel-polyfill', './src/main/index.js'],
+    entry: ['./src/main/index.js'],
     output: {
         path: path.resolve(__dirname, 'build'),
         filename: 'index.js',
@@ -12,10 +12,7 @@ module.exports = {
                 test: /\.js$/,
                 include: path.resolve(__dirname, 'src'),
                 use: {
-                    loader: 'babel-loader',
-                    options: {
-                        presets: ['env']
-                    }
+                    loader: 'babel-loader'
                 }
             }
         ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4980,11 +4980,6 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.2:
-  version "0.13.9"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
-  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
-
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"


### PR DESCRIPTION
We were using a couple of libraries to support browsers like IE11:

- regenerator-runtime: this transforms code that uses async / await to something old browsers can handle
- babel-polyfill: a polyfill for methods such as Object.entries

I just removed those, since our renderer doesn't support IE11 anyways.