### PR TITLE
Encapsulate chart container div

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,48 +15,20 @@ npm install --save @seatsio/seatsio-react
 ### Minimal
 
 ```jsx
-import { SeatsioSeatingChart } from '@seatsio/seatsio-react'
+import { SeatsioSeatingChart } from '@seatsio/seatsio-react';
 
-<SeatsioSeatingChart
-    workspaceKey="<yourPublicWorkspaceKey>"
-    event="<yourEventKey>"
-    region="eu"
-/>
+<div style={{ 'height': '500px' }}>
+    <SeatsioSeatingChart
+        workspaceKey="<yourPublicWorkspaceKey>"
+        event="<yourEventKey>"
+        region="eu"
+    />
+</div>
 ```
-
-### Setting the height of the chart
 
 By default, `<SeatsioSeatingChart>` is as wide as its parent div, and as high as the drawing that's rendered.
 
-To set an explicit height, use CSS on the div that gets created by `<SeatsioSeatingChart>`:
-
-```css
-#chart {
-    height: 800px; // or height: 100%, or height: 100vh, depending on your requirements
-}
-```
-
-### Custom chart div ID
-
-```jsx
-<SeatsioSeatingChart
-    workspaceKey="<yourPublicWorkspaceKey>"
-    event="<yourEventKey>"
-    id="<theChartDivID>"
-    region="eu"
-/>
-```
-
-### Custom chart div class
-
-```jsx
-<SeatsioSeatingChart
-    workspaceKey="<yourPublicWorkspaceKey>"
-    event="<yourEventKey>"
-    className="<theChartDivClassName>"
-    region="eu"
-/>
-```
+To set an explicit height, style the element (e.g. a div) that contains the `<SeatsioSeatingChart>`.
 
 ### onRenderStarted()
 
@@ -124,14 +96,16 @@ Whenever one of the properties passed on to `<SeatsioSeatingChart />` changes, t
 ## Event manager
 
 ```jsx
-import { SeatsioEventManager } from '@seatsio/seatsio-react'
+import { SeatsioEventManager } from '@seatsio/seatsio-react';
 
-<SeatsioEventManager
-    secretKey="<yourWorkspaceSecretKey>"
-    event="<yourEventKey>"
-    mode="<manageObjectStatuses or another mode>"
-    region="eu"
-/>
+<div style={{ 'height': '500px' }}>
+    <SeatsioEventManager
+        secretKey="<yourWorkspaceSecretKey>"
+        event="<yourEventKey>"
+        mode="<manageObjectStatuses or another mode>"
+        region="eu"
+    />
+</div>
 ```
 
 Other parameters are supported as well. For a full list, check https://docs.seats.io/docs/event-manager/configuring
@@ -139,14 +113,16 @@ Other parameters are supported as well. For a full list, check https://docs.seat
 ## Chart manager
 
 ```jsx
-import { SeatsioChartManager } from '@seatsio/seatsio-react'
+import { SeatsioChartManager } from '@seatsio/seatsio-react';
 
-<SeatsioChartManager
-    secretKey="<yourWorkspaceSecretKey>"
-    chart="<yourChartKey>"
-    mode="<manageRulesets or another mode>"
-    region="eu"
-/>
+<div style={{ 'height': '500px' }}>
+    <SeatsioChartManager
+        secretKey="<yourWorkspaceSecretKey>"
+        chart="<yourChartKey>"
+        mode="<manageRulesets or another mode>"
+        region="eu"
+    />
+</div>
 ```
 
 ## Seating Chart Designer
@@ -154,12 +130,14 @@ import { SeatsioChartManager } from '@seatsio/seatsio-react'
 To embed the seating chart designer for the purpose of creating a new chart, do this:
 
 ```jsx
-import { SeatsioDesigner } from '@seatsio/seatsio-react'
+import { SeatsioDesigner } from '@seatsio/seatsio-react';
 
-<SeatsioDesigner
-    secretKey="<yourWorkspaceSecretKey>"
-    region="eu"
-/>
+<div style={{ 'height': '500px' }}>
+    <SeatsioDesigner
+        secretKey="<yourWorkspaceSecretKey>"
+        region="eu"
+    />
+</div>
 ```
 
 To be able to edit a chart from an embedded designer, you need to specify the chart to load:
@@ -173,13 +151,3 @@ To be able to edit a chart from an embedded designer, you need to specify the ch
 ```
 
 Other parameters are supported as well. For a full list, check https://docs.seats.io/docs/embedded-designer-configuration
-
-### Setting the height of the designer
-
-By default, the chart designer gets rendered with a minimal height. To change that, use CSS on the div that gets created by `<SeatsioDesigner>`:
-
-```css
-#chart {
-    height: 800px; // or height: 100%, or height: 100vh, depending on your requirements
-}
-```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seatsio/seatsio-react",
-  "version": "11.0.0",
+  "version": "12.0.0",
   "main": "build/index.js",
   "repository": {
     "type": "git",

--- a/playground/src/App.js
+++ b/playground/src/App.js
@@ -31,12 +31,14 @@ class App extends React.Component {
                     <option>1</option>
                 </select>
                 <h1>Seats.io React playground</h1>
-                <SeatsioSeatingChart
-                    workspaceKey="publicDemoKey"
-                    event="theatreEvent"
-                    colorScheme={this.state.colorScheme}
-                    region="eu"
-                />
+                <div id="chart">
+                    <SeatsioSeatingChart
+                        workspaceKey="publicDemoKey"
+                        event="smallTheatreEvent1"
+                        colorScheme={this.state.colorScheme}
+                        region="eu"
+                    />
+                </div>
             </div>
         )
     }

--- a/src/main/Embeddable.js
+++ b/src/main/Embeddable.js
@@ -4,6 +4,11 @@ import React from 'react'
 import {didPropsChange} from './util'
 
 export default class Embeddable extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.container = React.createRef();
+    }
     async componentDidMount () {
         this.createAndRenderChart()
     }
@@ -18,7 +23,7 @@ export default class Embeddable extends React.Component {
     async createAndRenderChart () {
         const seatsio = await this.getSeatsio()
         const config = this.extractConfigFromProps()
-        config.divId = this.props.id
+        config.container = this.container.current
         this.chart = this.createChart(seatsio, config).render()
         if (this.props.onRenderStarted) {
             this.props.onRenderStarted(this.chart)
@@ -27,7 +32,7 @@ export default class Embeddable extends React.Component {
 
     extractConfigFromProps () {
         // noinspection JSUnusedLocalSymbols
-        let { id, className, onRenderStarted, chartJsUrl, region, ...config } = this.props
+        let { divId, container, onRenderStarted, chartJsUrl, region, ...config } = this.props
         return config
     }
 
@@ -67,12 +72,11 @@ export default class Embeddable extends React.Component {
 
     render () {
         return (
-            <div id={this.props.id} className={this.props.className}/>
+            <div ref={this.container} style={{'height': '100%'}} />
         )
     }
 }
 
 Embeddable.defaultProps = {
-    id: 'chart',
     chartJsUrl: 'https://cdn-{region}.seatsio.net/chart.js'
 }

--- a/src/test/SeatsioChartManager.test.js
+++ b/src/test/SeatsioChartManager.test.js
@@ -3,6 +3,7 @@ import Enzyme, {mount} from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import {SeatsioChartManager} from '../main/index'
 import Embeddable from '../main/Embeddable'
+import {removeContainer} from "./util";
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -10,7 +11,7 @@ describe('SeatsioChartManager', () => {
     let seatsioMock = {
         ChartManager: class {
             constructor (props) {
-                this.props = props
+                this.props = removeContainer(props)
             }
 
             render () {
@@ -28,20 +29,17 @@ describe('SeatsioChartManager', () => {
             <SeatsioChartManager/>
         ))
 
-        expect(chart.find('div#chart').length).toEqual(1)
+        expect(chart.find('div').length).toEqual(1)
     })
 
     it('passes parameters onto the chart manager', () => {
         return new Promise(resolve => {
             mount((
                 <SeatsioChartManager
-                    id="someID"
-                    className="someClassName"
                     secretKey="aSecretKey"
                     onRenderStarted={chart => {
                         expect(chart.props).toEqual({
-                            divId: 'someID',
-                            secretKey: 'aSecretKey',
+                            secretKey: 'aSecretKey'
                         })
                         resolve()
                     }}
@@ -54,15 +52,12 @@ describe('SeatsioChartManager', () => {
         return new Promise(resolve => {
             mount((
                 <SeatsioChartManager
-                    id="someID"
-                    className="someClassName"
                     secretKey="aSecretKey"
                     region="eu"
                     chartJsUrl="https://www.google.com"
                     onRenderStarted={chart => {
                         expect(chart.props).toEqual({
-                            divId: 'someID',
-                            secretKey: 'aSecretKey',
+                            secretKey: 'aSecretKey'
                         })
                         resolve()
                     }}

--- a/src/test/SeatsioDesigner.test.js
+++ b/src/test/SeatsioDesigner.test.js
@@ -3,6 +3,7 @@ import Enzyme, {mount} from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import {SeatsioChartManager, SeatsioDesigner} from '../main/index'
 import Embeddable from '../main/Embeddable'
+import {removeContainer} from "./util";
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -13,7 +14,7 @@ describe('SeatsioDesigner', () => {
         SeatingChartDesigner: class {
 
             constructor (props) {
-                this.props = props
+                this.props = removeContainer(props)
             }
 
             render () {
@@ -31,20 +32,17 @@ describe('SeatsioDesigner', () => {
             <SeatsioDesigner/>
         )
 
-        expect(chart.find('div#chart').length).toEqual(1)
+        expect(chart.find('div').length).toEqual(1)
     })
 
     it('passes parameters onto the designer', () => {
         return new Promise(resolve => {
             mount(
                 <SeatsioDesigner
-                    id="someID"
-                    className="someClassName"
                     designerKey="aDesignerKey"
                     onRenderStarted={chart => {
                         expect(chart.props).toEqual({
-                            divId: 'someID',
-                            designerKey: 'aDesignerKey',
+                            designerKey: 'aDesignerKey'
                         })
                         resolve()
                     }}/>
@@ -56,15 +54,12 @@ describe('SeatsioDesigner', () => {
         return new Promise(resolve => {
             mount(
                 <SeatsioDesigner
-                    id="someID"
-                    className="someClassName"
                     designerKey="aDesignerKey"
                     region="eu"
                     chartJsUrl="https://www.google.com"
                     onRenderStarted={chart => {
                         expect(chart.props).toEqual({
-                            divId: 'someID',
-                            designerKey: 'aDesignerKey',
+                            designerKey: 'aDesignerKey'
                         })
                         resolve()
                     }}/>

--- a/src/test/SeatsioEventManager.test.js
+++ b/src/test/SeatsioEventManager.test.js
@@ -3,6 +3,7 @@ import Enzyme, {mount} from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import {SeatsioChartManager, SeatsioEventManager} from '../main/index'
 import Embeddable from '../main/Embeddable'
+import {removeContainer} from "./util";
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -13,7 +14,7 @@ describe('SeatsioEventManager', () => {
         EventManager: class {
 
             constructor (props) {
-                this.props = props
+                this.props = removeContainer(props)
             }
 
             render () {
@@ -31,20 +32,17 @@ describe('SeatsioEventManager', () => {
             <SeatsioEventManager/>
         ))
 
-        expect(chart.find('div#chart').length).toEqual(1)
+        expect(chart.find('div').length).toEqual(1)
     })
 
     it('passes parameters onto the event manager', () => {
         return new Promise(resolve => {
             mount((
                 <SeatsioEventManager
-                    id="someID"
-                    className="someClassName"
                     workspaceKey="aworkspaceKey"
                     onRenderStarted={chart => {
                         expect(chart.props).toEqual({
-                            divId: 'someID',
-                            workspaceKey: 'aworkspaceKey',
+                            workspaceKey: 'aworkspaceKey'
                         })
                         resolve()
                     }}/>
@@ -56,15 +54,12 @@ describe('SeatsioEventManager', () => {
         return new Promise(resolve => {
             mount((
                 <SeatsioEventManager
-                    id="someID"
-                    className="someClassName"
                     workspaceKey="aworkspaceKey"
                     region="eu"
                     chartJsUrl="https://www.google.com"
                     onRenderStarted={chart => {
                         expect(chart.props).toEqual({
-                            divId: 'someID',
-                            workspaceKey: 'aworkspaceKey',
+                            workspaceKey: 'aworkspaceKey'
                         })
                         resolve()
                     }}/>

--- a/src/test/SeatsioSeatingChart.test.js
+++ b/src/test/SeatsioSeatingChart.test.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import Enzyme, {mount} from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
-import {SeatsioChartManager, SeatsioSeatingChart} from '../main/index'
+import {SeatsioSeatingChart} from '../main/index'
 import Embeddable from '../main/Embeddable'
+import {removeContainer} from "./util";
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -13,7 +14,7 @@ describe('SeatsioSeatingChart', () => {
         SeatingChart: class {
 
             constructor (props) {
-                this.props = props
+                this.props = removeContainer(props)
             }
 
             render () {
@@ -26,55 +27,26 @@ describe('SeatsioSeatingChart', () => {
         return Promise.resolve(seatsioMock)
     }
 
-    it('renders the chart in a div with default ID "chart"', () => {
-        let chart = mount((
-            <SeatsioSeatingChart/>
-        ))
-
-        expect(chart.find('div#chart').length).toEqual(1)
-    })
-
     it('renders the chart with default properties', () => {
         return new Promise(resolve => {
             mount((
                 <SeatsioSeatingChart
                     onRenderStarted={chart => {
-                        expect(chart.props).toEqual({
-                            divId: 'chart'
-                        })
+                        expect(chart.props).toEqual({})
                         resolve()
                     }}/>
             ))
         })
     })
 
-    it('renders the chart in a div with the specified ID', () => {
-        let chart = mount((
-            <SeatsioSeatingChart id="mySuperDuperChart"/>
-        ))
-
-        expect(chart.find('div#mySuperDuperChart').length).toEqual(1)
-    })
-
-    it('adds the specified class', () => {
-        let chart = mount((
-            <SeatsioSeatingChart className="charty"/>
-        ))
-
-        expect(chart.find('div.charty').length).toEqual(1)
-    })
-
     it('passes parameters onto the chart', () => {
         return new Promise(resolve => {
             mount((
                 <SeatsioSeatingChart
-                    id="someID"
-                    className="someClassName"
                     workspaceKey="aworkspaceKey"
                     onRenderStarted={chart => {
                         expect(chart.props).toEqual({
-                            divId: 'someID',
-                            workspaceKey: 'aworkspaceKey',
+                            workspaceKey: 'aworkspaceKey'
                         })
                         resolve()
                     }}/>
@@ -86,15 +58,12 @@ describe('SeatsioSeatingChart', () => {
         return new Promise(resolve => {
             mount((
                 <SeatsioSeatingChart
-                    id="someID"
-                    className="someClassName"
                     workspaceKey="aworkspaceKey"
                     region="eu"
                     chartJsUrl="https://www.google.com"
                     onRenderStarted={chart => {
                         expect(chart.props).toEqual({
-                            divId: 'someID',
-                            workspaceKey: 'aworkspaceKey',
+                            workspaceKey: 'aworkspaceKey'
                         })
                         resolve()
                     }}/>
@@ -136,19 +105,6 @@ describe('SeatsioSeatingChart', () => {
                     }}
                 />
             ))
-        })
-    })
-
-    it('re-renders if props change', () => {
-        return new Promise(resolve => {
-            let chartComponent = mount(<SeatsioSeatingChart/>)
-            chartComponent.setProps({
-                id: 'someID',
-                onRenderStarted: chart => {
-                    expect(chart.props.divId).toBe('someID')
-                    resolve()
-                }
-            })
         })
     })
 })

--- a/src/test/util.js
+++ b/src/test/util.js
@@ -1,0 +1,4 @@
+export function removeContainer(config) {
+    let { container, ...configWithoutContainer } = config
+    return configWithoutContainer
+}


### PR DESCRIPTION
I removed the `divId` parameter which you could pass in when rendering a chart. We now don't set an ID on the chart container div anymore. This makes it very easy to show multiple charts on the same page.

It's also not possible anymore to define a `className` on the container div. All styling should be applied to the parent element of `<SeatsioSeatingChart>`, over which the user has full control.