### PR TITLE
Make @seatsio/seatsio-types a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
   "files": [
     "build/"
   ],
+  "dependencies": {
+    "@seatsio/seatsio-types": "0.3.2"
+  },
   "peerDependencies": {
     "react": ">=18.0.0"
   },
   "devDependencies": {
-    "@seatsio/seatsio-types": "0.3.2",
     "@testing-library/jest-dom": "6.1.3",
     "@testing-library/react": "14.0.0",
     "@types/jest": "29.5.5",


### PR DESCRIPTION
If only a `devDependency`, users of `@seatsio/seatsio-react` are forced to add `seatsio-types` themselves, which should be unnecessary.