### PR TITLE
fix: Fix `tsup` config by re-enabling the `bundle` config

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,5 +8,4 @@ export default defineConfig({
   sourcemap: true,
   dts: true,
   minify: true,
-  bundle: false,
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,5 +7,5 @@ export default defineConfig({
   target: "es2019",
   sourcemap: true,
   dts: true,
-  minify: true,
+  splitting: false,
 });


### PR DESCRIPTION
Shoot, so sorry to have to come back with another PR so quick. There was one issue that I had run into a couple times while testing my previous change to this package (#137), in which the package couldn't find the `SeatsioDesigner` file. After installing your most recent version, I ended up still having this issue:

![Screenshot 2023-10-31 at 2 52 19 PM](https://github.com/seatsio/seatsio-react/assets/9214195/f4559a6a-b760-480e-9a7b-0a5d23da0dd6)

I realized that this is caused by the `bundle: false` option in the `tsup` config. By default, this feature is turned on, and when it is on, the relative imports for mjs files within a project all generally included their file extensions (`import foo from ./foo.mjs`). Without this, projects using ESM will not find this file. The node ecosystem has gotten really inconsistent lately haha.

The only reason I had turned this off in the first place was because it chunks the mjs files into separate pieces to allow for bundle splitting, which produces a build output that was much further removed looking than your old setup. There's nothing wrong with it though, and without those file extensions this package will most likely be broken for all ESM projects.

This issue has more info on the topic: https://github.com/egoist/tsup/issues/953

---

Sorry again for the fast follow!