### PR TITLE
Upgrade seatsio-types to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build/"
   ],
   "dependencies": {
-    "@seatsio/seatsio-types": "2.0.0"
+    "@seatsio/seatsio-types": "2.0.1"
   },
   "peerDependencies": {
     "react": ">=18.0.0"

--- a/playground/package.json
+++ b/playground/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@seatsio/seatsio-react": "file:./..",
+    "@seatsio/seatsio-react": "link:./..",
     "@types/node": "20.8.10",
     "@types/react": "18.2.30",
     "@types/react-dom": "18.2.14",

--- a/playground/package.json
+++ b/playground/package.json
@@ -33,5 +33,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11"
   }
 }

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -82,7 +82,7 @@
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
-"@babel/helper-annotate-as-pure@^7.22.5":
+"@babel/helper-annotate-as-pure@^7.18.6", "@babel/helper-annotate-as-pure@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz#e7f06737b197d580a01edf75d97e2c8be99d3882"
   integrity sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==
@@ -107,7 +107,7 @@
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.22.11", "@babel/helper-create-class-features-plugin@^7.22.15", "@babel/helper-create-class-features-plugin@^7.22.5":
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.21.0", "@babel/helper-create-class-features-plugin@^7.22.11", "@babel/helper-create-class-features-plugin@^7.22.15", "@babel/helper-create-class-features-plugin@^7.22.5":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.15.tgz#97a61b385e57fe458496fad19f8e63b63c867de4"
   integrity sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==
@@ -357,6 +357,16 @@
   version "7.21.0-placeholder-for-preset-env.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz#7844f9289546efa9febac2de4cfe358a050bd703"
   integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
+
+"@babel/plugin-proposal-private-property-in-object@7.21.11":
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
+  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-create-class-features-plugin" "^7.21.0"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -1665,15 +1665,14 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.5.1.tgz#5f1b518ec5fa54437c0b7c4a821546c64fed6922"
   integrity sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==
 
-"@seatsio/seatsio-react@file:./..":
-  version "14.2.0"
-  dependencies:
-    "@seatsio/seatsio-types" "2.0.0"
+"@seatsio/seatsio-react@link:./..":
+  version "0.0.0"
+  uid ""
 
-"@seatsio/seatsio-types@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-2.0.0.tgz#2563d5f4483cf1d8835d78dff0110de226602afb"
-  integrity sha512-RSK9OgzbrjewkjcsmqkK4XGGhbdnv4x/UsjLI4M8c4ax+XGzxOX2vlQyD3wA///UcOgcVCvTcYJYF83Pt/123w==
+"@seatsio/seatsio-types@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-2.0.1.tgz#f07e1b05e3dedc6cb049213ad4de4907593c5da2"
+  integrity sha512-8yIzPhVtzHoVrOjJaNQXw0sqLkAdBzQH1WtQTCqLTPkPMlIGO/kzCoMDQ+K0kcTHq8yQLhI5/L+EoqTL255lHg==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"

--- a/src/main/Embeddable.tsx
+++ b/src/main/Embeddable.tsx
@@ -63,10 +63,10 @@ export default abstract class Embeddable<T extends CommonConfigOptions> extends 
         }
     }
 
-    getSeatsio () {
+    getSeatsio (): Promise<Seatsio> {
         if (typeof seatsio === 'undefined') {
             return this.loadSeatsio()
-        } else if (seatsio.region !== this.props.region) {
+        } else if ((seatsio as any).region !== this.props.region) {
             seatsio = undefined
             return this.loadSeatsio()
         } else {
@@ -74,11 +74,11 @@ export default abstract class Embeddable<T extends CommonConfigOptions> extends 
         }
     }
 
-    loadSeatsio () {
+    loadSeatsio (): Promise<Seatsio> {
         return new Promise((resolve, reject) => {
             let script = document.createElement('script')
             script.onload = () => {
-                seatsio.region = this.props.region
+                (seatsio as any).region = this.props.region
                 resolve(seatsio)
             }
             script.onerror = () => reject(`Could not load ${script.src}`)

--- a/src/test/SeatsioDesigner.test.tsx
+++ b/src/test/SeatsioDesigner.test.tsx
@@ -8,7 +8,7 @@ import { ChartDesignerConfigOptions } from '@seatsio/seatsio-types'
 
 describe('SeatsioDesigner', () => {
 
-    let seatsioMock = {
+    let seatsioMock: any = {
         SeatingChartDesigner: class {
             public props: ChartDesignerConfigOptions
 

--- a/src/test/SeatsioEventManager.test.tsx
+++ b/src/test/SeatsioEventManager.test.tsx
@@ -8,7 +8,7 @@ import { TestSeatingChart } from '../types'
 
 describe('SeatsioEventManager', () => {
 
-    let seatsioMock = {
+    let seatsioMock: any = {
 
         EventManager: class {
             public props: EventManagerConfigOptions

--- a/src/test/SeatsioSeatingChart.test.tsx
+++ b/src/test/SeatsioSeatingChart.test.tsx
@@ -8,7 +8,7 @@ import { ChartRendererConfigOptions } from '@seatsio/seatsio-types';
 
 describe('SeatsioSeatingChart', () => {
 
-    let seatsioMock = {
+    let seatsioMock: any = {
 
         SeatingChart: class {
             public props: ChartRendererConfigOptions

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,9 +1,5 @@
 import { SeatingChart } from "@seatsio/seatsio-types"
 
-declare global {
-    var seatsio: any
-}
-
 export type TestSeatingChart = SeatingChart & { 
     props?: any,
     state?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,10 +697,10 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@seatsio/seatsio-types@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-2.0.0.tgz#2563d5f4483cf1d8835d78dff0110de226602afb"
-  integrity sha512-RSK9OgzbrjewkjcsmqkK4XGGhbdnv4x/UsjLI4M8c4ax+XGzxOX2vlQyD3wA///UcOgcVCvTcYJYF83Pt/123w==
+"@seatsio/seatsio-types@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-2.0.1.tgz#f07e1b05e3dedc6cb049213ad4de4907593c5da2"
+  integrity sha512-8yIzPhVtzHoVrOjJaNQXw0sqLkAdBzQH1WtQTCqLTPkPMlIGO/kzCoMDQ+K0kcTHq8yQLhI5/L+EoqTL255lHg==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"


### PR DESCRIPTION
Version 2.0.1 of `@seatsio/seatsio-types` exports its own global `seatsio` definition, which required removal of our `seatsio: any` definition and some tweaks to tests.

Also fixes a build warning due to missing devDependency of `@babel/plugin-proposal-private-property-in-object`.