### PR TITLE
Rewrite seatsio loading to not use rendering promise

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -7,6 +7,7 @@ type ColorScheme = 'light' | 'dark'
 export const App = () => {
   const [unusedState, setUnusedState] = useState(0)
   const [colorScheme, setColorScheme] = useState<ColorScheme>('light')
+  const [shown, setShown] = useState(true)
 
   return (
     <div className={['container', colorScheme].join(' ')}>
@@ -19,8 +20,13 @@ export const App = () => {
                 <option>0</option>
                 <option>1</option>
             </select>
+            <select onChange={e => setShown(e.target.value === 'true')} value={shown + ''}>
+                <option value="true">true</option>
+                <option value="false">false</option>
+            </select>
             <h1>Seats.io React playground</h1>
             <div id="chart">
+                {shown &&
                 <SeatsioSeatingChart
                     workspaceKey="publicDemoKey"
                     event="smallTheatreEvent1"
@@ -28,6 +34,7 @@ export const App = () => {
                     region="eu"
                     chartJsUrl="https://cdn-staging-{region}.seatsio.net/chart.js"
                 />
+                }
             </div>
         </div>
     </div>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -21,8 +21,8 @@ export const App = () => {
                 <option>1</option>
             </select>
             <select onChange={e => setShown(e.target.value === 'true')} value={shown + ''}>
-                <option value="true">true</option>
-                <option value="false">false</option>
+                <option value="true">visible</option>
+                <option value="false">hidden</option>
             </select>
             <h1>Seats.io React playground</h1>
             <div id="chart">

--- a/src/main/Embeddable.tsx
+++ b/src/main/Embeddable.tsx
@@ -11,6 +11,7 @@ export type EmbeddableProps<T > = {
 export default abstract class Embeddable<T extends CommonConfigOptions> extends React.Component<EmbeddableProps<T>> {
     private container: React.RefObject<HTMLDivElement>
     private chart: SeatingChart
+    private firstRender: boolean
 
     private static seatsioBundles: { [key: string]: Promise<Seatsio> } = {}
 
@@ -21,12 +22,16 @@ export default abstract class Embeddable<T extends CommonConfigOptions> extends 
     constructor(props: EmbeddableProps<T>) {
         super(props);
         this.container = React.createRef()
+        this.firstRender = true
     }
 
     abstract createChart (seatsio: Seatsio, config: T): SeatingChart | EventManager | ChartDesigner
 
     componentDidMount () {
-        !Embeddable.seatsioBundles[this.getChartUrl()] && this.createAndRenderChart()
+        if (!Embeddable.seatsioBundles[this.getChartUrl()] || this.firstRender) {
+            this.createAndRenderChart()
+            this.firstRender = false
+        }
     }
 
     componentDidUpdate (prevProps: EmbeddableProps<T>) {

--- a/src/main/Embeddable.tsx
+++ b/src/main/Embeddable.tsx
@@ -41,8 +41,7 @@ export default abstract class Embeddable<T extends CommonConfigOptions> extends 
     }
 
     async createAndRenderChart () {
-        const seatsio = await this.loadSeatsio();
-        (seatsio as any).region = this.props.region
+        const seatsio = await this.loadSeatsio()
         const config = this.extractConfigFromProps()
         config.container = this.container.current
         this.chart = this.createChart(seatsio, config).render()
@@ -71,6 +70,8 @@ export default abstract class Embeddable<T extends CommonConfigOptions> extends 
         if (!Embeddable.seatsioBundles[chartUrl]) {
             Embeddable.seatsioBundles[chartUrl] = new Promise<Seatsio>((resolve, reject) => {
                 const script = document.head.appendChild(document.createElement('script'))
+                // Seatsio global is not replaced if already present, which would cause the wrong region bundle to resolve when changing region
+                window.seatsio = undefined
                 script.onload = () => {
                     resolve(seatsio)
                 }

--- a/src/main/Embeddable.tsx
+++ b/src/main/Embeddable.tsx
@@ -37,7 +37,7 @@ export default abstract class Embeddable<T extends CommonConfigOptions> extends 
     }
 
     async createAndRenderChart () {
-        window.seatsio = await this.loadSeatsio();
+        const seatsio = await this.loadSeatsio();
         (seatsio as any).region = this.props.region
         const config = this.extractConfigFromProps()
         config.container = this.container.current

--- a/src/main/Embeddable.tsx
+++ b/src/main/Embeddable.tsx
@@ -2,8 +2,8 @@ import * as React from 'react'
 import {didPropsChange} from './util'
 import { ChartDesigner, CommonConfigOptions, EventManager, Region, SeatingChart, Seatsio } from '@seatsio/seatsio-types'
 
-export type EmbeddableProps<T> = {
-    onRenderStarted?: (chart: SeatingChart) => void
+export type EmbeddableProps<T > = {
+    onRenderStarted?: (chart: SeatingChart | EventManager) => void
     chartJsUrl?: string
     region: Region
 } & T

--- a/src/main/Embeddable.tsx
+++ b/src/main/Embeddable.tsx
@@ -79,6 +79,8 @@ export default abstract class Embeddable<T extends CommonConfigOptions> extends 
     }
 
     render (): React.ReactNode {
-        return <div ref={this.container as unknown as React.RefObject<HTMLDivElement>} style={{'height': '100%', 'width': '100%'}} />
+        return (
+            <div ref={this.container as unknown as React.RefObject<HTMLDivElement>} style={{'height': '100%', 'width': '100%'}} />
+        )
     }
 }


### PR DESCRIPTION
Rewrites Embeddable.tsx code to not use `rendering` promise. This was based on some feedback from a library user, although I'm not sure it was the root of the observed issue. It's however not a standard pattern, so I've made some changes.

- Changes to `region` would trigger a reload, and with the current implementation script tags to the same region script could be added multiple times. This is now handled by retaining a static reference keyed on the `Region` value.
- Adds a fix to `onRenderStarted` to accommodate both renderer and event manager