### PR TITLE
Upgrade seatsio-types to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build/"
   ],
   "dependencies": {
-    "@seatsio/seatsio-types": "2.0.1"
+    "@seatsio/seatsio-types": "2.0.2"
   },
   "peerDependencies": {
     "react": ">=18.0.0"

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -1679,10 +1679,10 @@
   version "0.0.0"
   uid ""
 
-"@seatsio/seatsio-types@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-2.0.1.tgz#f07e1b05e3dedc6cb049213ad4de4907593c5da2"
-  integrity sha512-8yIzPhVtzHoVrOjJaNQXw0sqLkAdBzQH1WtQTCqLTPkPMlIGO/kzCoMDQ+K0kcTHq8yQLhI5/L+EoqTL255lHg==
+"@seatsio/seatsio-types@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-2.0.2.tgz#a37ac348ce7dbf69e894db5911562aa8b5c0e9fc"
+  integrity sha512-I5LvC6YMYjpxYEwXnhjS7Ywom7vudyjrTivhBI+08SD/rrSFXb9Vm7TeHlx2gaRSKOzxE9YzbVafEhtNZdz9Rw==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,10 +697,10 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@seatsio/seatsio-types@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-2.0.1.tgz#f07e1b05e3dedc6cb049213ad4de4907593c5da2"
-  integrity sha512-8yIzPhVtzHoVrOjJaNQXw0sqLkAdBzQH1WtQTCqLTPkPMlIGO/kzCoMDQ+K0kcTHq8yQLhI5/L+EoqTL255lHg==
+"@seatsio/seatsio-types@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@seatsio/seatsio-types/-/seatsio-types-2.0.2.tgz#a37ac348ce7dbf69e894db5911562aa8b5c0e9fc"
+  integrity sha512-I5LvC6YMYjpxYEwXnhjS7Ywom7vudyjrTivhBI+08SD/rrSFXb9Vm7TeHlx2gaRSKOzxE9YzbVafEhtNZdz9Rw==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"


### PR DESCRIPTION
Upgraded `@seatsio/seatsio-types` to version 2.0.2. This fixes an issue where EventManager renderer callback chart was typed as `SeatingChart`.