### PR TITLE
Don't unnecessarily re-export seatsio-types

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,4 +1,5 @@
 import { SeatsioSeatingChart } from '@seatsio/seatsio-react';
+import { Region } from '@seatsio/seatsio-types';
 import React, { useState } from 'react';
 import './App.css';
 
@@ -8,6 +9,7 @@ export const App = () => {
   const [unusedState, setUnusedState] = useState(0)
   const [colorScheme, setColorScheme] = useState<ColorScheme>('light')
   const [shown, setShown] = useState(true)
+  const region: Region = 'eu'
 
   return (
     <div className={['container', colorScheme].join(' ')}>
@@ -31,7 +33,7 @@ export const App = () => {
                     workspaceKey="publicDemoKey"
                     event="smallTheatreEvent1"
                     colorScheme={colorScheme}
-                    region="eu"
+                    region={region}
                     chartJsUrl="https://cdn-staging-{region}.seatsio.net/chart.js"
                 />
                 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,4 +2,3 @@ export { default as SeatsioDesigner } from './SeatsioDesigner'
 export { default as SeatsioEventManager } from './SeatsioEventManager'
 export { default as SeatsioSeatingChart } from './SeatsioSeatingChart'
 export { isBooth, isGeneralAdmission, isSeat, isSection, isTable } from './util'
-export type * from '@seatsio/seatsio-types';


### PR DESCRIPTION
As far as I can tell it's not necessary to re-export `seatsio-types` from `seatsio-react` (or from any of our client-side libs). We list `seatsio-types` as a dependency, so it gets installed under `node_modules`, which makes it available to client code.

This seems to work in our playground.

If I'm missing something, please let me know 😉 