### PR TITLE
Re-export definitions from `@seatsio/seatsio-types`, to make eslint happy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ The chart uses 100% of the width and height of the DOM element (e.g. a div) in w
 
 ### TypeScript
 
-The `@seatsio/seatsio-types` package (which comes installed with `@seatsio/seatsio-react`) provides type definitions for the properties of the `SeatsioSeatingChart`:
+`@seatsio/seatsio-react` exposes type definitions from `@seatsio/seatsio-types`. You can import them as follows:
 
 ```jsx
-import { Pricing } from "@seatsio/seatsio-types";
+import { SeatsioSeatingChart, Pricing } from "@seatsio/seatsio-react";
 
 const pricing: Pricing = [
     { category: '1', price: 30},

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,5 +1,4 @@
-import { SeatsioSeatingChart } from '@seatsio/seatsio-react';
-import { Region } from '@seatsio/seatsio-types';
+import { SeatsioSeatingChart, Region } from '@seatsio/seatsio-react';
 import React, { useState } from 'react';
 import './App.css';
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,3 +2,4 @@ export { default as SeatsioDesigner } from './SeatsioDesigner'
 export { default as SeatsioEventManager } from './SeatsioEventManager'
 export { default as SeatsioSeatingChart } from './SeatsioSeatingChart'
 export { isBooth, isGeneralAdmission, isSeat, isSection, isTable } from './util'
+export type * from '@seatsio/seatsio-types';


### PR DESCRIPTION
@csandman mentioned in https://github.com/seatsio/seatsio-react/pull/149 that the Airbnb eslint config forbids importing code from transitive dependencies. So it complains when you import types from `@seatsio/seatsio-types` if you don't have it listed explicitly in your `package.json`.

That's a good point, so now we're exporting all types from `@seatsio/seatsio-types` once again.