### PR TITLE
Component allows updating callbacks such as `onObjectSelected`

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -34,7 +34,7 @@ export const App = () => {
                     colorScheme={colorScheme}
                     region={region}
                     chartJsUrl="https://cdn-staging-{region}.seatsio.net/chart.js"
-                    onObjectSelected={(object) => console.log(unusedState)}
+                    onObjectSelected={(object) => console.log(colorScheme)}
                 />
                 }
             </div>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -34,6 +34,7 @@ export const App = () => {
                     colorScheme={colorScheme}
                     region={region}
                     chartJsUrl="https://cdn-staging-{region}.seatsio.net/chart.js"
+                    onObjectSelected={(object) => console.log(unusedState)}
                 />
                 }
             </div>

--- a/src/main/Embeddable.tsx
+++ b/src/main/Embeddable.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import {didPropsChange} from './util'
-import { ChartDesigner, CommonConfigOptions, EventManager, Region, SeatingChart, Seatsio } from '@seatsio/seatsio-types'
+import {ChartDesigner, CommonConfigOptions, EventManager, Region, SeatingChart, Seatsio} from '@seatsio/seatsio-types'
 
-export type EmbeddableProps<T > = {
+export type EmbeddableProps<T> = {
     onRenderStarted?: (chart: SeatingChart | EventManager) => void
     chartJsUrl?: string
     region: Region
@@ -35,6 +35,8 @@ export default abstract class Embeddable<T extends CommonConfigOptions> extends 
     }
 
     componentDidUpdate (prevProps: EmbeddableProps<T>) {
+        // @ts-ignore
+        this.chart.config = this.extractConfigFromProps()
         if (didPropsChange(this.props, prevProps) && this.chart) {
             this.destroyChart()
             this.createAndRenderChart()
@@ -48,7 +50,6 @@ export default abstract class Embeddable<T extends CommonConfigOptions> extends 
     async createAndRenderChart () {
         const seatsio = await this.loadSeatsio()
         const config = this.extractConfigFromProps()
-        config.container = this.container.current
         this.chart = this.createChart(seatsio, config).render()
         if (this.props.onRenderStarted) {
             this.props.onRenderStarted(this.chart)
@@ -57,6 +58,8 @@ export default abstract class Embeddable<T extends CommonConfigOptions> extends 
 
     extractConfigFromProps (): any {
         let { chartJsUrl, divId, onRenderStarted, region, ...config } = this.props
+        // @ts-ignore
+        config.container = this.container.current
         return config
     }
 


### PR DESCRIPTION
Context: https://github.com/seatsio/seatsio-react/issues/198

Currently, it's not possible to modify the definition of callbacks (e.g. `onObjectSelected` or `onObjectDeselected`).

That's an issue when you reference state variables inside the callback:

```jsx
// Created by @csandman 
import { useState } from 'react';
import { SeatsioSeatingChart } from '@seatsio/seatsio-react';

function App() {
  const [count, setCount] = useState(0);

  const onObjectSelected = () => {
    console.log('Count:', count);
  };

  return (
    <main>
      <button onClick={() => setCount((count) => count + 1)}>
        count is {count} (click to increment)
      </button>
      <div className="seatmap-container">
        <SeatsioSeatingChart
          workspaceKey="publicDemoKey"
          region="eu"
          fitTo="widthAndHeight"
          event="largeStadiumEvent"
          onObjectSelected={onObjectSelected}
        />
      </div>
    </main>
  );
}
```

This code will always log `Count: 0` upon selection of an object.

As a fix, I modified our code to apply the updated callbacks to the seating chart config. Ideally this logic should move out of `seatsio-react` and into `seatsio.SeatingChart`. If not, we'll need to duplicate the fix to `seatsio-react-native`.